### PR TITLE
Update meta.yml

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,9 +18,12 @@ jobs:
       matrix:
         image:
           - 'mathcomp/mathcomp:2.3.0-coq-8.20'
-          - 'mathcomp/mathcomp:2.3.0-coq-dev'
+          - 'mathcomp/mathcomp:2.4.0-coq-8.20'
+          - 'mathcomp/mathcomp:2.4.0-rocq-prover-9.0'
+          - 'mathcomp/mathcomp:2.4.0-rocq-prover-dev'
           - 'mathcomp/mathcomp-dev:coq-8.20'
-          - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp-dev:rocq-prover-9.0'
+          - 'mathcomp/mathcomp-dev:rocq-prover-dev'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -37,25 +37,25 @@ remains the sole trusted code base.
   - Frédéric Chyzak (initial)
   - Assia Mahboubi (initial)
   - Thomas Sibut-Pinote (initial)
-- Coq-community maintainer(s):
+- Rocq-community maintainer(s):
   - Assia Mahboubi ([**@amahboubi**](https://github.com/amahboubi))
   - Kazuhiko Sakaguchi ([**@pi8027**](https://github.com/pi8027))
 - License: [CeCILL-C](LICENSE)
-- Compatible Coq versions: 8.20 or later
+- Compatible Rocq/Coq versions: 8.20 or later
 - Additional dependencies:
-  - [MathComp ssreflect 2.3 or later](https://math-comp.github.io)
+  - [MathComp ssreflect](https://math-comp.github.io) 2.3 or later
   - [MathComp algebra](https://math-comp.github.io)
   - [MathComp field](https://math-comp.github.io)
-  - [CoqEAL 2.0.4 or later](https://github.com/coq-community/coqeal)
-  - [MathComp real closed fields 2.0.0 or later](https://github.com/math-comp/real-closed)
-  - [MathComp bigenough 1.0.1 or later](https://github.com/math-comp/bigenough)
-  - [Mczify](https://github.com/math-comp/mczify) 1.5.0 or later
-  - [Algebra Tactics](https://github.com/math-comp/algebra-tactics) 1.2.2 or later
-- Coq namespace: `mathcomp.apery`
+  - [CoqEAL](https://github.com/coq-community/coqeal) 2.1.0 or later
+  - [MathComp real closed fields](https://github.com/math-comp/real-closed)
+  - [MathComp bigenough](https://github.com/math-comp/bigenough) 1.0.1 or later
+  - [Mczify](https://github.com/math-comp/mczify)
+  - [Algebra Tactics](https://github.com/math-comp/algebra-tactics)
+- Rocq/Coq namespace: `mathcomp.apery`
 - Related publication(s):
   - [A Formal Proof of the Irrationality of ζ(3)](https://arxiv.org/abs/1912.06611) 
   - [A Computer-Algebra-Based Formal Proof of the Irrationality of ζ(3)](https://hal.inria.fr/hal-00984057) doi:[10.1007/978-3-319-08970-6_11](https://doi.org/10.1007/978-3-319-08970-6_11)
-  - [Reflexive Tactics for Algebra, Revisited](https://drops.dagstuhl.de/opus/volltexte/2022/16738/pdf/LIPIcs-ITP-2022-29.pdf) doi:[10.4230/LIPIcs.ITP.2022.29](https://doi.org/10.4230/LIPIcs.ITP.2022.29)
+  - [Reflexive tactics for algebra, revisited](https://drops.dagstuhl.de/opus/volltexte/2022/16738/pdf/LIPIcs-ITP-2022-29.pdf) doi:[10.4230/LIPIcs.ITP.2022.29](https://doi.org/10.4230/LIPIcs.ITP.2022.29)
 
 ## Building and installation instructions
 

--- a/coq-mathcomp-apery.opam
+++ b/coq-mathcomp-apery.opam
@@ -23,15 +23,15 @@ remains the sole trusted code base."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.20" & < "9.1~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "2.3" & < "2.4~") | (= "dev")}
+  "coq" {>= "8.20"}
+  "coq-mathcomp-ssreflect" {>= "2.3"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-field" 
-  "coq-coqeal" {>= "2.0.4"}
-  "coq-mathcomp-real-closed" {>= "2.0.0"}
+  "coq-coqeal" {>= "2.1.0"}
+  "coq-mathcomp-real-closed" 
   "coq-mathcomp-bigenough" {>= "1.0.1"}
-  "coq-mathcomp-zify" {>= "1.5.0"}
-  "coq-mathcomp-algebra-tactics" {>= "1.2.2"}
+  "coq-mathcomp-zify" 
+  "coq-mathcomp-algebra-tactics" 
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -25,7 +25,7 @@ publications:
   pub_title: A Computer-Algebra-Based Formal Proof of the Irrationality of ζ(3)
   pub_doi: 10.1007/978-3-319-08970-6_11
 - pub_url: https://drops.dagstuhl.de/opus/volltexte/2022/16738/pdf/LIPIcs-ITP-2022-29.pdf
-  pub_title: Reflexive Tactics for Algebra, Revisited
+  pub_title: Reflexive tactics for algebra, revisited
   pub_doi: 10.4230/LIPIcs.ITP.2022.29
 
 authors:
@@ -52,24 +52,30 @@ license:
 
 supported_coq_versions:
   text: 8.20 or later
-  opam: '{(>= "8.20" & < "9.1~") | (= "dev")}'
+  opam: '{>= "8.20"}'
 
 tested_coq_opam_versions:
 - version: '2.3.0-coq-8.20'
   repo: 'mathcomp/mathcomp'
-- version: '2.3.0-coq-dev'
+- version: '2.4.0-coq-8.20'
+  repo: 'mathcomp/mathcomp'
+- version: '2.4.0-rocq-prover-9.0'
+  repo: 'mathcomp/mathcomp'
+- version: '2.4.0-rocq-prover-dev'
   repo: 'mathcomp/mathcomp'
 - version: 'coq-8.20'
   repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-dev'
+- version: 'rocq-prover-9.0'
+  repo: 'mathcomp/mathcomp-dev'
+- version: 'rocq-prover-dev'
   repo: 'mathcomp/mathcomp-dev'
 
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{(>= "2.3" & < "2.4~") | (= "dev")}'
+    version: '{>= "2.3"}'
   description: |-
-    [MathComp ssreflect 2.1 or later](https://math-comp.github.io)
+    [MathComp ssreflect](https://math-comp.github.io) 2.3 or later
 - opam:
     name: coq-mathcomp-algebra
   description: |-
@@ -80,29 +86,26 @@ dependencies:
     [MathComp field](https://math-comp.github.io)
 - opam:
     name: coq-coqeal
-    version: '{>= "2.0.4"}'
+    version: '{>= "2.1.0"}'
   description: |-
-    [CoqEAL 2.0.4 or later](https://github.com/coq-community/coqeal)
+    [CoqEAL](https://github.com/coq-community/coqeal) 2.1.0 or later
 - opam:
     name: coq-mathcomp-real-closed
-    version: '{>= "2.0.0"}'
   description: |-
-    [MathComp real closed fields 2.0.0 or later](https://github.com/math-comp/real-closed)
+    [MathComp real closed fields](https://github.com/math-comp/real-closed)
 - opam:
     name: coq-mathcomp-bigenough
     version: '{>= "1.0.1"}'
   description: |-
-    [MathComp bigenough 1.0.1 or later](https://github.com/math-comp/bigenough)
+    [MathComp bigenough](https://github.com/math-comp/bigenough) 1.0.1 or later
 - opam:
     name: coq-mathcomp-zify
-    version: '{>= "1.5.0"}'
   description: |-
-    [Mczify](https://github.com/math-comp/mczify) 1.5.0 or later
+    [Mczify](https://github.com/math-comp/mczify)
 - opam:
     name: coq-mathcomp-algebra-tactics
-    version: '{>= "1.2.2"}'
   description: |-
-    [Algebra Tactics](https://github.com/math-comp/algebra-tactics) 1.2.2 or later
+    [Algebra Tactics](https://github.com/math-comp/algebra-tactics)
 
 namespace: mathcomp.apery
 


### PR DESCRIPTION
This PR does a few things:
- Update CI,
- Remove the upper version constraints on coq and coq-mathcomp-ssreflect (it does not make much sense in the dev repo),
- Fix the version constraints on CoqEAL (2.0.4 does not even exist), and
- Remove some version constraints that can be implied from other constraints.